### PR TITLE
Null checking client before sending statistics

### DIFF
--- a/client/src/main/java/pro/panopticon/client/responsetimelogger/AbstractResponseTimeLogger.java
+++ b/client/src/main/java/pro/panopticon/client/responsetimelogger/AbstractResponseTimeLogger.java
@@ -33,7 +33,9 @@ public class AbstractResponseTimeLogger implements Sensor {
         List<CloudwatchStatistic> toSubmit = this.counts;
         counts = new Vector<>();
 
-        cloudwatchClient.sendStatistics(namespace, toSubmit);
+        if (cloudwatchClient != null) {
+            cloudwatchClient.sendStatistics(namespace, toSubmit);
+        }
 
         // This sensor returns no measurements for now – it's just implemented as a sensor for similarity to the other concepts
         return Collections.emptyList();


### PR DESCRIPTION
In some cases - as when developing on a local machine - users don't want to send statistics and therefore haven't specified the Cloudwatch client. This commit addresses the issue of such cases that has resulted in NPEs.