### PR TITLE
Add method for logging and ticking exceptions with stack trace 🐛

### DIFF
--- a/client/src/main/java/pro/panopticon/client/eventlogger/AbstractEventLogger.java
+++ b/client/src/main/java/pro/panopticon/client/eventlogger/AbstractEventLogger.java
@@ -7,6 +7,8 @@ import pro.panopticon.client.awscloudwatch.HasCloudwatchConfig;
 import pro.panopticon.client.model.Measurement;
 import pro.panopticon.client.sensor.Sensor;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -34,6 +36,16 @@ public class AbstractEventLogger implements Sensor {
 
     public void tickAndLog(HasEventInfo event, String... logappends) {
         tickAndLog(event, 1, logappends);
+    }
+
+    public void tickAndLogException(HasEventInfo event, Exception e) {
+        tickAndLog(event, 1, stackTraceToString(e));
+    }
+
+    private String stackTraceToString(Exception e) {
+        StringWriter stringWriter = new StringWriter();
+        e.printStackTrace(new PrintWriter(stringWriter));
+        return stringWriter.toString();
     }
 
     public void tickAndLog(HasEventInfo event, double count, String... logappends) {


### PR DESCRIPTION
### Overview
* Adds public method `public void tickAndLogException(HasEventInfo event, Exception e)` to the panopticon-client

### Motivation 
Allows users to easily log the exception stack trace. Logging the stack trace is useful for debug purposes.

### Example use case
```kotlin
        try {
            return objectMapper.readValue(resultBody, Train::class.java)
        } catch (e: Exception) {
            EventLogger.INSTANCE.tickAndLogException(TRAIN_PARSING_ERROR, e)
            throw e
        }
```